### PR TITLE
Add a configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ The folded state is ONLY for poc projects, since it requires additional resource
 Enable it in config, by adding:
 
 `'stacked'=> false,`
+
+### Configuration
+This package publishes the configuration file `config/frontqueue.php` and allows for the Gearman servers to be defined in the `.env` file using the `FRONTQUEUE_GEARMAN_SERVERS` environment variable.
+
+The config value is expected to be in the format `host1:port1[,host2:port2[,...]]` since the connection is performed with the `GearmanClient::addServers()` method.

--- a/src/Cloudoki/FrontQueue/FrontQueueServiceProvider.php
+++ b/src/Cloudoki/FrontQueue/FrontQueueServiceProvider.php
@@ -31,13 +31,18 @@ class FrontQueueServiceProvider extends ServiceProvider {
 	public function register()
 	{
 
+		$this->publishes (
+		[
+			__DIR__.'/../../config/frontqueue.php' => config_path ('frontqueue.php')
+		], 'config');
+
 		$this->app['frontqueue'] = $this->app->share(function($app)
-        {
-            return env('APP_ENV', 'development') == 'local'?
-            	
-            	new FrontLocalQueue():
-            	new FrontQueue();
-        });
+		{
+			return env('APP_ENV', 'development') == 'local'?
+
+				new FrontLocalQueue():
+				new FrontQueue();
+		});
 	}
 
 	/**

--- a/src/config/frontqueue.php
+++ b/src/config/frontqueue.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Gearman Server Config
+	|--------------------------------------------------------------------------
+	|
+	| This value determines the Gearman Job Servers to which the application will
+	| connect. The connection is done with the GearmanClient::addServers() method.
+	| Thus, the config value is expected to be 'host:port' or
+	| 'host1:port1,host2:port2[,...]'.
+	|
+	*/
+	'gearman' => [
+		'servers' => env('FRONTQUEUE_GEARMAN_SERVERS', '127.0.0.1:4730')
+	],
+
+];


### PR DESCRIPTION
The machine where I'm using this package on is for some reason not resolving "localhost" to 127.0.0.1 inside PHP.

This package can be configured through the `app.gearman.servers` variable but I'd rather not add that configuration to my site's `config/app.php` file manually.

This PR adds a configuration file to this package that will also be published to the main project. Also, it allows for the Gearman servers to be specified through the `FRONTQUEUE_GEARMAN_SERVERS` environment variable.
